### PR TITLE
Remove stroke from bg rect

### DIFF
--- a/svgscreen/template.svg
+++ b/svgscreen/template.svg
@@ -20,7 +20,7 @@ so currently using <use> instead.
 {{- if gt (len $.BackgroundColors) 0}}
     <svg style="display: none">
 {{- range $i, $c := $.BackgroundColors}}
-        <rect id="b{{$i}}" width="{{$.CharacterBoxSize.Width}}" height="{{$.CharacterBoxSize.Height}}" stroke-width="1px" stroke="{{$c}}" style="fill: {{$c}}"/>
+        <rect id="b{{$i}}" width="{{$.CharacterBoxSize.Width}}" height="{{$.CharacterBoxSize.Height}}" stroke-width="0px" style="fill: {{$c}}"/>
 {{- end}}
     </svg>
 {{- end}}


### PR DESCRIPTION
The 1px stroke around the background rects exceeds the area supposed to be filled. Remove stroke so only the area defined by CharacterBoxSize is filled.