### PR TITLE
Separate SVG DOM information to dedicated struct

### DIFF
--- a/ansitosvg/ansisvg.go
+++ b/ansitosvg/ansisvg.go
@@ -137,10 +137,12 @@ func Convert(r io.Reader, w io.Writer, opts Options) error {
 			"14": c.ANSIBrightCyan,
 			"15": c.ANSIBrightWhite,
 		},
-		FontName:     fontName,
-		FontEmbedded: opts.FontEmbedded,
-		FontRef:      opts.FontRef,
-		FontSize:     opts.FontSize,
+		Dom: svgscreen.SvgDom{
+			FontName:     fontName,
+			FontEmbedded: opts.FontEmbedded,
+			FontRef:      opts.FontRef,
+			FontSize:     opts.FontSize,
+		},
 		CharacterBoxSize: svgscreen.BoxSize{
 			Width:  opts.CharacterBoxSize.Width,
 			Height: opts.CharacterBoxSize.Height,

--- a/svgscreen/svgscreen.go
+++ b/svgscreen/svgscreen.go
@@ -56,26 +56,30 @@ type bgRect struct {
 	Color  string
 }
 
+type SvgDom struct {
+	Width        string
+	Height       string
+	FontName     string
+	FontEmbedded []byte
+	FontRef      string
+	FontSize     int
+	BgRects      []bgRect
+	TextElements []textElement
+}
+
 type Screen struct {
 	Transparent      bool
 	ForegroundColor  string
 	ForegroundColors map[string]string
 	BackgroundColor  string
 	BackgroundColors map[string]string
-	FontName         string
-	FontEmbedded     []byte
-	FontRef          string
-	FontSize         int
 	CharacterBoxSize BoxSize
 	TerminalWidth    int
 	Columns          int
 	NrLines          int
 	Lines            []Line
-	TextElements     []textElement
-	BgRects          []bgRect
 	GridMode         bool
-	SvgWidth         string
-	SvgHeight        string
+	Dom              SvgDom
 }
 
 func (s *Screen) columnCoordinate(col int) string {
@@ -205,7 +209,7 @@ func (s *Screen) setupBgRects() {
 			if currentRect.color == "" {
 				return
 			}
-			s.BgRects = append(s.BgRects, bgRect{
+			s.Dom.BgRects = append(s.Dom.BgRects, bgRect{
 				X:      s.columnCoordinate(currentRect.x),
 				Y:      s.rowCoordinate(float32(y)),
 				Width:  s.columnCoordinate(currentRect.w),
@@ -238,8 +242,8 @@ func (s *Screen) Render(w io.Writer) error {
 	})
 
 	// Set SVG size
-	s.SvgWidth = s.columnCoordinate(s.TerminalWidth)
-	s.SvgHeight = s.rowCoordinate(float32(s.NrLines))
+	s.Dom.Width = s.columnCoordinate(s.TerminalWidth)
+	s.Dom.Height = s.rowCoordinate(float32(s.NrLines))
 
 	s.handleColorInversion()
 	s.setupBgRects()
@@ -248,7 +252,7 @@ func (s *Screen) Render(w io.Writer) error {
 	for _, l := range s.Lines {
 		fg := s.lineToTextElement(l)
 		if len(fg.TextSpans) > 0 {
-			s.TextElements = append(s.TextElements, fg)
+			s.Dom.TextElements = append(s.Dom.TextElements, fg)
 		}
 	}
 

--- a/svgscreen/template.svg
+++ b/svgscreen/template.svg
@@ -7,22 +7,22 @@ so currently using <use> instead.
 xml:space="preserve" is used to forces some svg readers (ex inkscape) to not collapse
 whitespace only tspan:s preventing underline to be properly rendered.
 */ -}}
-<svg width="{{$.SvgWidth}}" height="{{$.SvgHeight}}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+<svg width="{{$.Dom.Width}}" height="{{$.Dom.Height}}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
     <style>
-        {{- if gt (len $.FontEmbedded) 0}}
+        {{- if gt (len $.Dom.FontEmbedded) 0}}
         @font-face {
-            font-family: {{$.FontName}};
-            src: url(data:;base64,{{- base64 $.FontEmbedded}});
+            font-family: {{$.Dom.FontName}};
+            src: url(data:;base64,{{- base64 $.Dom.FontEmbedded}});
         }
-        {{- else if ne $.FontRef ""}}
+        {{- else if ne $.Dom.FontRef ""}}
         @font-face {
-            font-family: {{$.FontName}};
-            src: url({{$.FontRef}});
+            font-family: {{$.Dom.FontName}};
+            src: url({{$.Dom.FontRef}});
         }
         {{- end}}
         * {
-            font-family: {{if $.FontName}}{{$.FontName}}, {{end}}monospace;
-            font-size: {{$.FontSize}}px;
+            font-family: {{if $.Dom.FontName}}{{$.Dom.FontName}}, {{end}}monospace;
+            font-size: {{$.Dom.FontSize}}px;
         }
         tspan, text {
             font-variant-ligatures: none;
@@ -34,10 +34,10 @@ whitespace only tspan:s preventing underline to be properly rendered.
 {{- if not .Transparent}}
     <rect width="100%" height="100%" x="0" y="0" style="fill: {{$.BackgroundColor}}"/>
 {{- end}}
-{{- range $ri, $r := .BgRects}}
+{{- range $ri, $r := .Dom.BgRects}}
 <rect x="{{$r.X}}" y="{{$r.Y}}" width="{{$r.Width}}" height="{{$r.Height}}" stroke-width="0.5px" stroke="{{$r.Color}}" style="fill:{{$r.Color}}"/>
 {{- end}}
-{{- range $li, $l := .TextElements}}
+{{- range $li, $l := .Dom.TextElements}}
 <text x="0" y="{{$l.Y}}">{{- range $si, $s := $l.TextSpans}}<tspan{{if ne $s.X ""}} x="{{ $s.X }}"{{end}}{{if ne $s.Style ""}} style="{{ $s.Style }}"{{end}}{{if ne $s.Decoration ""}} text-decoration="{{ $s.Decoration }}"{{end}}>{{$s.Content}}</tspan>{{- /* no new line */ -}}{{- end}}</text>
 {{- end}}
 </svg>


### PR DESCRIPTION
This is a pure cosmetic change and doesn't change the function at all.

I thought `svgscreen.Screen` was getting to big and messy and broke out the fields that are not used internally but passed verbatim to the SVG template to a separate struct.