### PR TITLE
Use getopt style short/long argument flags (without using getopt package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,27 +16,24 @@ Produces [colortest.ansi.svg](cli/testdata/colortest.ansi.svg):
 
 ```
 $ ansisvg -h
-Usage of ansisvg:
-  -charboxsize value
-    	Character box size (forces pixel units instead of font-relative units)
-  -colorscheme string
-    	Color scheme (default "Builtin Dark")
-  -fontfile string
-    	Font file to use and embed
-  -fontname string
-    	Font name (default "Courier")
-  -fontref string
-    	External font file to reference
-  -fontsize int
-    	Font size (default 14)
-  -grid
-    	Enable grid mode (sets position for each character)
-  -listcolorschemes
-    	List color schemes
-  -transparent
-    	Transparent background
-  -width int
-    	Terminal width (auto)
+ansisvg - Convert ANSI to SVG
+Usage: ansisvg [FLAGS]
+
+Example usage:
+  program | ansisvg > file.svg
+
+--charboxsize       Character box size (use pixel units instead of font units)
+--colorscheme       Color scheme
+--fontfile          Font file to use and embed
+--fontname          Font name
+--fontref           External font URL to use
+--fontsize          Font size
+--grid              Grid mode (sets position for each character)
+--help, -h          Show help
+--listcolorschemes  List color schemes
+--transparent       Transparent background
+--version, -v       Show version
+--width, -w         Terminal width (auto if not set)
 ```
 
 Color themes are the ones from https://github.com/mbadolato/iTerm2-Color-Schemes

--- a/ansitosvg/ansisvg.go
+++ b/ansitosvg/ansisvg.go
@@ -10,23 +10,23 @@ import (
 )
 
 type Options struct {
-	FontName         string
-	FontEmbedded     []byte
-	FontRef          string
-	FontSize         int
-	TerminalWidth    int
-	CharacterBoxSize svgscreen.BoxSize
-	ColorScheme      string
-	Transparent      bool
-	GridMode         bool
+	FontName      string
+	FontEmbedded  []byte
+	FontRef       string
+	FontSize      int
+	TerminalWidth int
+	CharBoxSize   svgscreen.BoxSize
+	ColorScheme   string
+	Transparent   bool
+	GridMode      bool
 }
 
 var DefaultOptions = Options{
-	FontName:         "Courier",
-	FontSize:         14,
-	CharacterBoxSize: svgscreen.BoxSize{Width: 0, Height: 0},
-	ColorScheme:      "Builtin Dark",
-	Transparent:      false,
+	FontName:    "Courier",
+	FontSize:    14,
+	CharBoxSize: svgscreen.BoxSize{Width: 0, Height: 0},
+	ColorScheme: "Builtin Dark",
+	Transparent: false,
 }
 
 // Convert reads ANSI input from r and writes SVG to w
@@ -130,8 +130,8 @@ func Convert(r io.Reader, w io.Writer, opts Options) error {
 			FontSize:     opts.FontSize,
 		},
 		CharacterBoxSize: svgscreen.BoxSize{
-			Width:  opts.CharacterBoxSize.Width,
-			Height: opts.CharacterBoxSize.Height,
+			Width:  opts.CharBoxSize.Width,
+			Height: opts.CharBoxSize.Height,
 		},
 		TerminalWidth: terminalWidth,
 		Columns:       ad.MaxX + 1,

--- a/cli/testdata/charboxfontsize.ansi.args
+++ b/cli/testdata/charboxfontsize.ansi.args
@@ -1,1 +1,1 @@
--fontsize 40 -fontname Arial -charboxsize 50x50 -grid
+--fontsize 40 --fontname Arial --charboxsize 50x50 --grid

--- a/cli/testdata/colortest_slate.ansi.args
+++ b/cli/testdata/colortest_slate.ansi.args
@@ -1,1 +1,1 @@
--colorscheme Slate
+--colorscheme Slate

--- a/cli/testdata/colortest_transparent.ansi.args
+++ b/cli/testdata/colortest_transparent.ansi.args
@@ -1,1 +1,1 @@
--transparent
+--transparent

--- a/cli/testdata/fontembedded.ansi.args
+++ b/cli/testdata/fontembedded.ansi.args
@@ -1,1 +1,1 @@
--fontfile UbuntuMonoNerdFontMono-Regular.woff2
+--fontfile UbuntuMonoNerdFontMono-Regular.woff2

--- a/cli/testdata/fontname.ansi.args
+++ b/cli/testdata/fontname.ansi.args
@@ -1,1 +1,1 @@
--fontname Monaco
+--fontname Monaco

--- a/cli/testdata/fontref.ansi.args
+++ b/cli/testdata/fontref.ansi.args
@@ -1,1 +1,1 @@
--fontref font.woff2
+--fontref font.woff2

--- a/cli/testdata/powerline.ansi.args
+++ b/cli/testdata/powerline.ansi.args
@@ -1,1 +1,1 @@
--fontfile UbuntuMonoNerdFontMono-Regular.woff2 -grid
+--fontfile UbuntuMonoNerdFontMono-Regular.woff2 --grid

--- a/cli/testdata/terminalwidth4.ansi.args
+++ b/cli/testdata/terminalwidth4.ansi.args
@@ -1,1 +1,1 @@
--width 4
+--width 4

--- a/cli/testdata/underlinetabs_backgroundcolor.ansi.args
+++ b/cli/testdata/underlinetabs_backgroundcolor.ansi.args
@@ -1,1 +1,1 @@
--colorscheme "Builtin Solarized Light"
+--colorscheme "Builtin Solarized Light"


### PR DESCRIPTION
Alternative to #30 without using getopt package. One difference is that multiple short flags can't be combined ex: `-ab` instead of `-a -b` does not work.