### PR TITLE
fix: viewBox attr when using pixel units

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ go build -o ansisvg .
 
 By default, `ansisvg` uses font-relative `ch`/`em` coordinates. This should make SVG dimensions and line/character spacing consistent with font family/size. When SVG dimensions and/or text coordinates are off, it is possible to force explicit pixel units for coordinates by specifying `-charboxsize` in X/Y pixel units, e.g. `8x16`.
 
-Inkscape currently [cannot deal with SVG size expressed in font-relative units](https://gitlab.com/inkscape/inkscape/-/issues/4737), a quick workaround is Ctrl-Shift-R (resize page to content).
+* Inkscape currently [cannot deal with SVG size expressed in font-relative units](https://gitlab.com/inkscape/inkscape/-/issues/4737), a quick workaround is Ctrl-Shift-R (resize page to content).
+
+* Some SVG processing tools like [asciidoctor](https://docs.asciidoctor.org/pdf-converter/latest/image-paths-and-formats/#image-formats) require the presence of the `viewBox` attribute. Use `-charboxsize` option to enable this attribute (it only works with pixel dimensions).
 
 ## Margin size
 

--- a/cli/testdata/charboxfontsize.svg
+++ b/cli/testdata/charboxfontsize.svg
@@ -1,4 +1,4 @@
-<svg width="250px" height="100px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+<svg width="250px" height="100px" viewBox="0 0 250 100" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
     <style>
         * {
             font-family: Arial, monospace;

--- a/cli/testdata/margintest_gridmode.svg
+++ b/cli/testdata/margintest_gridmode.svg
@@ -1,4 +1,4 @@
-<svg width="556px" height="260px" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+<svg width="556px" height="260px" viewBox="0 0 556 260" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
     <style>
         * {
             font-family: Courier, monospace;

--- a/svgscreen/svgscreen.go
+++ b/svgscreen/svgscreen.go
@@ -55,6 +55,7 @@ type bgRect struct {
 type SvgDom struct {
 	Width          string
 	Height         string
+	ViewBox        string
 	FontName       string
 	FontEmbedded   []byte
 	FontRef        string
@@ -308,10 +309,14 @@ func (s *Screen) Render(w io.Writer) error {
 		// Font-relative coordinates
 		s.Dom.Width = s.columnCoordinate(float32(s.TerminalWidth)+2*s.MarginSize.X, false)
 		s.Dom.Height = s.rowCoordinate(float32(s.NrLines)+2*s.MarginSize.Y, false)
+		s.Dom.ViewBox = ""
 	} else {
 		// Pixel coordinates
-		s.Dom.Width = fmt.Sprintf("%gpx", float32(s.CharacterBoxSize.X*s.TerminalWidth)+2*s.MarginSize.X)
-		s.Dom.Height = fmt.Sprintf("%gpx", float32(s.CharacterBoxSize.Y*s.NrLines)+2*s.MarginSize.Y)
+		w := float32(s.CharacterBoxSize.X*s.TerminalWidth) + 2*s.MarginSize.X
+		h := float32(s.CharacterBoxSize.Y*s.NrLines) + 2*s.MarginSize.Y
+		s.Dom.Width = fmt.Sprintf("%gpx", w)
+		s.Dom.Height = fmt.Sprintf("%gpx", h)
+		s.Dom.ViewBox = fmt.Sprintf("0 0 %g %g", w, h)
 	}
 
 	s.handleColorInversion()

--- a/svgscreen/template.svg
+++ b/svgscreen/template.svg
@@ -7,7 +7,7 @@ so currently using <use> instead.
 xml:space="preserve" is used to forces some svg readers (ex inkscape) to not collapse
 whitespace only tspan:s preventing underline to be properly rendered.
 */ -}}
-<svg width="{{$.Dom.Width}}" height="{{$.Dom.Height}}" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
+<svg width="{{$.Dom.Width}}" height="{{$.Dom.Height}}" {{- if ne $.Dom.ViewBox "" }} viewBox="{{$.Dom.ViewBox}}"{{- end }} xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve">
     <style>
         {{- if gt (len $.Dom.FontEmbedded) 0}}
         @font-face {


### PR DESCRIPTION
fixes SVG output for tools that rely on viewBox, such as asciidoctor

fixes #49 

From SVG documentation it appears that `viewBox` only supports pixel units, so I just add it when we use pixels